### PR TITLE
Remove dependency on `unstable-list-lib`

### DIFF
--- a/games/maze/map.rkt
+++ b/games/maze/map.rkt
@@ -146,8 +146,7 @@
   (visit player-entry-cell)
 
   (let ()
-    (local-require data/heap
-                   unstable/function)
+    (local-require data/heap)
     (define (dig-until-seen c0)
       (define h
         (make-heap (λ (c1 c2)

--- a/info.rkt
+++ b/info.rkt
@@ -23,5 +23,4 @@
         "slideshow-lib"
         "typed-racket-lib"
         "unstable-contract-lib"
-        "unstable-list-lib"
         "racket-doc"))


### PR DESCRIPTION
Most of the functionality of that package will be moved into the core libraries by Racket PR #972, and `unstable-list-lib` will be removed from the main distribution.

This PR makes this package incompatible with Racket 6.2. To preserve compatibility, you can create a Racket 6.2-compatible branch in this repository and set up a version exception at pkgs.racket-lang.org

Even without the changes from this PR, this package will continue to work with future versions of Racket. It will, however, require installation of the `unstable-list-lib` package, as it will not be part of the main distribution in future versions.
